### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:alpine AS build
+ADD . src/github.com/6f7262/kipp
+RUN apk update && \
+    apk add git build-base && \
+    go get -v github.com/6f7262/kipp/cmd/kipp && \
+    go build -v -o /kipp github.com/6f7262/kipp/cmd/kipp
+
+FROM alpine
+COPY --from=build /kipp /
+ADD default /
+RUN mkdir -p /data/files && \
+    ln -s /data/files /files && \
+    ln -s /data/kipp.db /kipp.db
+CMD ["/kipp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ ADD . src/github.com/6f7262/kipp
 RUN apk update && \
     apk add git build-base && \
     go get -v github.com/6f7262/kipp/cmd/kipp && \
-    go build -v -ldflags "-linkmode external -extldflags -static" -o 
-/kipp github.com/6f7262/kipp/cmd/kipp
+    go build -v -ldflags "-linkmode external -extldflags -static" -o /kipp github.com/6f7262/kipp/cmd/kipp
 
 FROM scratch
 COPY --from=build /kipp /

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,10 @@ ADD . src/github.com/6f7262/kipp
 RUN apk update && \
     apk add git build-base && \
     go get -v github.com/6f7262/kipp/cmd/kipp && \
-    go build -v -o /kipp github.com/6f7262/kipp/cmd/kipp
+    go build -v -ldflags "-linkmode external -extldflags -static" -o 
+/kipp github.com/6f7262/kipp/cmd/kipp
 
-FROM alpine
+FROM scratch
 COPY --from=build /kipp /
 ADD default /
-RUN mkdir -p /data/files && \
-    ln -s /data/files /files && \
-    ln -s /data/kipp.db /kipp.db
 CMD ["/kipp"]


### PR DESCRIPTION
This enables you to run kipp inside of Docker.

**before merging**:

- [x] symlink bug
- [x] tls self-signed bug
- [x] assert that go get will not refetch manually added kipp files

---

**various commands** (assuming you're cd'd in the git repo):

building the image:

`docker build -t kipp .`

running the locally built image (self-signed cert, persistent files):

`docker run -p 8000:443 -v /home/yours/kipp-data:/data kipp`

running the locally built image (your own cert, persistent files):

*this assumes you have `cert.pem` and `key.pem` inside of `/home/yours/kipp-ssl`*

`docker run -p 8000:443 -v /home/yours/kipp-data:/data -v /home/yours/kipp-ssl:/ssl:ro kipp /kipp --key /ssl/key.pem --cert /ssl/cert.pem`
