### PR TITLE
Serve Content-Location for supported FileSystems

### DIFF
--- a/filesystem/fs.go
+++ b/filesystem/fs.go
@@ -22,8 +22,19 @@ type Writer interface {
 	Sync() error
 }
 
-// A Reader is a readable, seekable stream for reading files.
+// A Reader is a readable, seekable and closable file stream.
 type Reader interface {
 	io.ReadSeeker
 	io.Closer
+}
+
+// The Locator interface is implemented by Readers that support resolving
+// a permanent URL location.
+//
+// The location will be served in the Content-Location header for the upstream
+// response.
+type Locator interface {
+	// Locate resolves a permanent, publicly accessible URL for the
+	// underlying content.
+	Locate(ctx context.Context) (string, error)
 }

--- a/filesystem/fs.go
+++ b/filesystem/fs.go
@@ -3,7 +3,6 @@ package filesystem
 import (
 	"context"
 	"io"
-	"time"
 )
 
 // A FileSystem is a persistent store of objects uniquely identified by name.
@@ -30,13 +29,13 @@ type Reader interface {
 }
 
 // The Locator interface is implemented by Readers that support resolving
-// a permanent URL location.
+// a publicly accessible URI.
 //
 // The location will be served in the Content-Location header for the upstream
 // response.
 type Locator interface {
-	// Locate resolves a publicly accessible URL for the underlying
-	// stream. The URL may expire, and the time must be reported correctly.
-	// If the URL does not expire, a zero time should be returned.
-	Locate(ctx context.Context) (location string, expire time.Time, err error)
+	// Locate resolves a publicly accessible URI for the underlying
+	// stream. The URI may expire, as long as it is relevant at the time the
+	// request was made.
+	Locate(ctx context.Context) (location string, err error)
 }

--- a/filesystem/fs.go
+++ b/filesystem/fs.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // A FileSystem is a persistent store of objects uniquely identified by name.
@@ -34,7 +35,8 @@ type Reader interface {
 // The location will be served in the Content-Location header for the upstream
 // response.
 type Locator interface {
-	// Locate resolves a permanent, publicly accessible URL for the
-	// underlying content.
-	Locate(ctx context.Context) (string, error)
+	// Locate resolves a publicly accessible URL for the underlying
+	// stream. The URL may expire, and the time must be reported correctly.
+	// If the URL does not expire, a zero time should be returned.
+	Locate(ctx context.Context) (location string, expire time.Time, err error)
 }

--- a/filesystem/local/local.go
+++ b/filesystem/local/local.go
@@ -28,7 +28,7 @@ func New(dir string) (*FileSystem, error) {
 func (fs FileSystem) Create(_ context.Context, name string) (filesystem.Writer, error) {
 	f, err := ioutil.TempFile(fs.tmp, "kipp")
 	if err != nil {
-		return nil, fmt.Errorf("temp writer: %w", err)
+		return nil, fmt.Errorf("temp file: %w", err)
 	}
 	return &writer{f: f, name: filepath.Join(fs.dir, name)}, nil
 }

--- a/filesystem/s3/reader.go
+++ b/filesystem/s3/reader.go
@@ -76,18 +76,11 @@ func (r *reader) reset() error {
 	return nil
 }
 
-// Locate pre-signs the object's URL and expires after 15 minutes.
-func (r *reader) Locate(_ context.Context) (string, time.Time, error) {
-	const expire = 15 * time.Minute
-	t := time.Now().Add(expire)
-
+// Locate presigns the object's URI and expires after 15 minutes.
+func (r *reader) Locate(_ context.Context) (string, error) {
 	req, _ := r.client.GetObjectRequest(&s3.GetObjectInput{
 		Bucket: &r.bucket,
 		Key:    &r.name,
 	})
-	l, err := req.Presign(expire)
-	if err != nil {
-		return "", time.Time{}, fmt.Errorf("presign: %w", err)
-	}
-	return l, t, nil
+	return req.Presign(15 * time.Minute)
 }

--- a/filesystem/s3/s3.go
+++ b/filesystem/s3/s3.go
@@ -40,16 +40,7 @@ func (fs *FileSystem) Create(ctx context.Context, name string) (filesystem.Write
 
 // Open gets the object with the specified key, name.
 func (fs *FileSystem) Open(ctx context.Context, name string) (filesystem.Reader, error) {
-	r := &reader{
-		ctx:    ctx,
-		client: fs.client,
-		bucket: fs.bucket,
-		name:   name,
-	}
-	if err := r.reset(); err != nil {
-		return nil, err
-	}
-	return r, nil
+	return newReader(ctx, fs.client, fs.bucket, name)
 }
 
 // Remove removes the s3 object specified with key, name, from the bucket.

--- a/filesystem/s3/writer.go
+++ b/filesystem/s3/writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
@@ -26,6 +27,7 @@ func newWriter(ctx context.Context, u *s3manager.Uploader, bucket, name string) 
 			Key:    &name,
 		})
 		if err != nil {
+			log.Println(err)
 			pr.CloseWithError(fmt.Errorf("upload: %w", err))
 		}
 		c <- err

--- a/filesystem/s3/writer.go
+++ b/filesystem/s3/writer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
@@ -27,7 +26,6 @@ func newWriter(ctx context.Context, u *s3manager.Uploader, bucket, name string) 
 			Key:    &name,
 		})
 		if err != nil {
-			log.Println(err)
 			pr.CloseWithError(fmt.Errorf("upload: %w", err))
 		}
 		c <- err

--- a/server.go
+++ b/server.go
@@ -136,7 +136,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			//      corresponding to this particular entity at the time of the request.
 			//
 			// We can therefore infer that this URI is only relevant
-			// for the time this request was made, such is may
+			// for the time this request was made, such it may
 			// expire in future.
 			w.Header().Set("Content-Location", l)
 		}

--- a/server.go
+++ b/server.go
@@ -131,7 +131,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return nil, fmt.Errorf("locate: %w", err)
 			}
 			w.Header().Set("Content-Location", l)
-			if expire.After(e) {
+			if e.Before(expire) {
 				expire = e
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -138,7 +138,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Cache-Control", fmt.Sprintf(
 			"public, must-revalidate, max-age=%d",
-			int(now.Sub(expire).Seconds()),
+			int(expire.Sub(now).Seconds()),
 		))
 		w.Header().Set("Content-Disposition", fmt.Sprintf(
 			"filename=%q; filename*=UTF-8''%[1]s",

--- a/server.go
+++ b/server.go
@@ -127,6 +127,15 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(ctype, prefix) {
 			ctype = "text/plain" + ctype[len(prefix):]
 		}
+
+		if l, ok := f.(filesystem.Locator); ok {
+			l, err := l.Locate(r.Context())
+			if err != nil {
+				return nil, fmt.Errorf("locate: %w", err)
+			}
+			w.Header().Set("Content-Location", l)
+		}
+
 		w.Header().Set("Cache-Control", cache)
 		w.Header().Set("Content-Disposition", fmt.Sprintf(
 			"filename=%q; filename*=UTF-8''%[1]s",


### PR DESCRIPTION
Regarding https://github.com/uhthomas/kipp/issues/21, returning a `Content-Location` header and letting upstream services take care of redirection, etc. has proven to be a simple and robust method of allowing content to be served from alternate locations. This can be revised in future.