### PR TITLE
Remove Locator

### DIFF
--- a/filesystem/fs.go
+++ b/filesystem/fs.go
@@ -27,15 +27,3 @@ type Reader interface {
 	io.ReadSeeker
 	io.Closer
 }
-
-// The Locator interface is implemented by Readers that support resolving
-// a publicly accessible URI.
-//
-// The location will be served in the Content-Location header for the upstream
-// response.
-type Locator interface {
-	// Locate resolves a publicly accessible URI for the underlying
-	// stream. The URI may expire, as long as it is relevant at the time the
-	// request was made.
-	Locate(ctx context.Context) (location string, err error)
-}

--- a/filesystem/s3/reader.go
+++ b/filesystem/s3/reader.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -74,13 +73,4 @@ func (r *reader) reset() error {
 		r.size = *obj.ContentLength
 	}
 	return nil
-}
-
-// Locate presigns the object's URI and expires after 15 minutes.
-func (r *reader) Locate(_ context.Context) (string, error) {
-	req, _ := r.client.GetObjectRequest(&s3.GetObjectInput{
-		Bucket: &r.bucket,
-		Key:    &r.name,
-	})
-	return req.Presign(15 * time.Minute)
 }


### PR DESCRIPTION
After some though, and real-world use I no longer believe including a `Content-Location` header is the correct thing to do.